### PR TITLE
[FIX] Readme: update installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 
 -   Clone the repo anywhere (with a terminal)
     -   git clone https://github.com/MrSweeter/vigilant-potato.git odoo-qol
-    -   cd odoo-qol
-    -   git checkout initial-version
 -   Open page chrome://extensions
 -   Activate developer mode
 -   Load unpacked extension


### PR DESCRIPTION
The branch `initial-version` does not exist anymore and the master branch is the default when cloning so there is no need to checkout anymore.